### PR TITLE
[codex] Validate manual S3 bucket updates

### DIFF
--- a/scripts/data/upload/s3_bucket.sh
+++ b/scripts/data/upload/s3_bucket.sh
@@ -7,7 +7,7 @@ GREEN='\033[0;32m'
 DARK_GRAY='\033[1;30m'
 
 # Read the current s3_bucket variable from upload.sh
-s3_bucket=$(grep -oP '(?<=s3_bucket=).+' scripts/data/upload/upload.sh)
+s3_bucket=$(awk -F= '/^s3_bucket=/{print $2}' scripts/data/upload/upload.sh | tr -d '"')
 
 # Display the current s3_bucket variable
 echo "Current s3_bucket: $s3_bucket"
@@ -17,15 +17,31 @@ read -p "Do you want to change the s3_bucket location? (y/n): " choice
 
 if [[ $choice == "y" || $choice == "Y" ]]; then
     # Display all the available buckets
-    aws s3 ls
+    if ! aws s3 ls; then
+        echo -e "${RED}Could not list buckets right now. You can still enter the full bucket URI manually.${NC}"
+    fi
 
     # Ask for the new location
-    echo ""
-    echo "Enter the full s3_bucket location, e.g. s3://my-bucket-name"
-    read -p "New s3_bucket location: " new_location
+    while true; do
+        echo ""
+        echo "Enter the full s3_bucket location, e.g. s3://my-bucket-name"
+        read -p "New s3_bucket location: " new_location
+
+        if [[ -z "$new_location" ]]; then
+            echo -e "${RED}s3_bucket location cannot be empty.${NC}"
+            continue
+        fi
+
+        if [[ ! "$new_location" =~ ^s3://[^[:space:]]+$ ]]; then
+            echo -e "${RED}Please enter the full bucket URI starting with s3://.${NC}"
+            continue
+        fi
+
+        break
+    done
 
     # Update the upload.sh file with the new location
-    sudo sed -i "s|s3_bucket=.*|s3_bucket=$new_location|" scripts/data/upload/upload.sh
+    sudo sed -i "s|^s3_bucket=.*|s3_bucket=\"$new_location\"|" scripts/data/upload/upload.sh
 
     echo -e "${GREEN}s3_bucket location updated successfully.${NC} Returning to main menu..."
     sleep 1.5


### PR DESCRIPTION
## What changed
- stop the bucket picker from overwriting `s3_bucket` with an empty value
- require a full `s3://...` URI before saving
- keep manual entry available even if `aws s3 ls` cannot list buckets
- preserve quoting when writing `s3_bucket` back into `upload.sh`

## Why
While verifying the AWS fix on the dhub server, the bucket-change flow showed that an empty response could silently blank out the configured bucket.

## Impact
The upload menu is more resilient during AWS troubleshooting and no longer destroys the saved bucket value on empty input.

## Validation
- live on the dhub server on April 13, 2026
- reproduced the bucket-change flow after the DNS repair
- confirmed empty input now shows a validation error
- confirmed a valid follow-up entry keeps `s3_bucket` set to `s3://oc4d-raw-reports`
