### PR TITLE
[codex] Make dhub visible in automation subfolder picker

### DIFF
--- a/scripts/data/automation/configure.sh
+++ b/scripts/data/automation/configure.sh
@@ -179,16 +179,29 @@ pick_bucket
 pick_subfolder(){
   local bucket_name="${S3_BUCKET#s3://}"; bucket_name="${bucket_name%%/*}"
   local opts=( "NONE" "<bucket root>" "CUSTOM" "Enter subfolder manually" )
+  local prefixes=()
   local out rc
   out="$(aws_capture s3api list-objects-v2 --bucket "$bucket_name" --delimiter '/' --query 'CommonPrefixes[].Prefix' --output text 2>&1)"; rc=$?
   if (( rc == 0 )) && [[ -n "$out" && "$out" != "None" ]]; then
-    while IFS= read -r p; do p="${p%/}"; [[ -n "$p" ]] && opts+=( "$p" "$p" ); done < <(printf '%s' "$out" | tr '\t' '\n' | sed '/^ *$/d')
+    while IFS= read -r p; do
+      p="${p%/}"
+      [[ -n "$p" ]] && prefixes+=( "$p" )
+    done < <(printf '%s' "$out" | tr '\t' '\n' | sed '/^ *$/d')
   else
     out="$(aws_capture s3 ls "s3://$bucket_name/" 2>&1 || true)"
     while IFS= read -r line; do
-      if [[ "$line" == PRE* ]]; then p="$(echo "$line" | awk '{print $2}' | sed 's:/$::')"; [[ -n "$p" ]] && opts+=( "$p" "$p" ); fi
+      if [[ "$line" == PRE* ]]; then
+        p="$(echo "$line" | awk '{print $2}' | sed 's:/$::')"
+        [[ -n "$p" ]] && prefixes+=( "$p" )
+      fi
     done <<< "$out"
   fi
+  if [[ -n "$S3_SUBFOLDER" ]]; then
+    prefixes+=( "$(sanitize_subfolder "$S3_SUBFOLDER")" )
+  fi
+  while IFS= read -r p; do
+    [[ -n "$p" ]] && opts+=( "$p" "$p" )
+  done < <(printf '%s\n' "${prefixes[@]}" | sed '/^$/d' | sort -fu)
   choice="$(menu_select_cancelable "Select S3 subfolder in s3://$bucket_name/" 20 74 12 "${opts[@]}")"
   [[ "$choice" == "__EXIT__" ]] && exit 2
   case "$choice" in


### PR DESCRIPTION
## What changed
- make the automation S3 subfolder picker collect prefixes first and sort them case-insensitively
- include the currently configured subfolder in the picker list even if it would otherwise fall outside the immediately visible slice

## Why
On the dhub server, the lowercase `dhub/` prefix existed in S3 and was already configured in `config/automation.conf`, but it was effectively buried below the visible menu entries because uppercase prefixes sorted ahead of lowercase ones.

## Impact
The `dhub` subfolder now appears in the visible automation picker list instead of looking like it is missing.

## Validation
- verified live on the dhub server on April 13, 2026
- confirmed AWS returns `dhub/` in `CommonPrefixes`
- confirmed the sorted preview now places `dhub` near the top of the menu list
